### PR TITLE
use &body for macro body forms

### DIFF
--- a/src/dolist.lisp
+++ b/src/dolist.lisp
@@ -1,7 +1,7 @@
 (in-package :trivial-do)
 
 
-(defmacro dolist* ((position-var value-var list-form &optional result-form) &rest body)
+(defmacro dolist* ((position-var value-var list-form &optional result-form) &body body)
   "dolist* iterates over the elements of an list and binds position-var to the index of each
 element, value-var to each element and then evaluates body as a tagbody that can include
 declarations. Finally the result-form is returned after the iteration completes."

--- a/src/doseq.lisp
+++ b/src/doseq.lisp
@@ -1,7 +1,7 @@
 (in-package :trivial-do)
 
 
-(defmacro doseq* ((position-var value-var seq-form &optional result-form) &rest body)
+(defmacro doseq* ((position-var value-var seq-form &optional result-form) &body body)
   "doseq* iterates over the elements of an sequence and binds position-var to the index of each
 element, value-var to each element and then evaluates body as a tagbody that can include
 declarations. Finally the result-form is returned after the iteration completes."
@@ -30,7 +30,7 @@ declarations. Finally the result-form is returned after the iteration completes.
            (go ,repeat))))))
 
 
-(defmacro doseq ((var seq-form &optional result-form) &rest body)
+(defmacro doseq ((var seq-form &optional result-form) &body body)
   "doseq iterates over the elements of an sequence and binds value-var to successive values
 and then evaluates body as a tagbody that can include declarations. Finally the result-form
 is returned after the iteration completes."


### PR DESCRIPTION
Slime/Sly and other environments indent macro body forms with 2 spaces, but only if they are denoted with `&body` in the macro's lambda-list. If `&rest` is used, these environments try to align the arguments like so:

```lisp
(dolist* (pos item (list 1 2 3))
         (print pos)
         (print item))
```

This PR fixes that; after this change, Slime and Sly indent correctly:

```lisp
(dolist* (pos item (list 1 2 3))
  (print pos)
  (print item))
```